### PR TITLE
Add trim function for go and test cases

### DIFF
--- a/trim.go
+++ b/trim.go
@@ -19,9 +19,8 @@ type toStringAble interface {
 // function from the package strings. For more detailed information about the
 // trim function in the package strings, see the [strings's trim documentation]
 //
-// NOTE: Implementation of second parameter of Trim is not complete yet. This
-// function does not support specifying a set of characters using string ranges
-// (e.g., "a..z") in the chars parameter.
+// NOTE: This function does not support the second parameter of original parse_str yet.
+// It only strips the default characters (" \n\r\t\v\x00")
 //
 // References:
 //   - https://www.php.net/manual/en/function.trim.php
@@ -38,22 +37,8 @@ type toStringAble interface {
 //
 // [official PHP documentation]: https://www.php.net/manual/en/function.trim.php
 // [strings's trim documentation]: https://pkg.go.dev/strings#Trim
-func Trim(value any, chars ...any) any {
-	var charSet string
-
-	// If the `chars` is not provided or is an empty string, set the default character set
-	if len(chars) == 0 {
-		charSet = " \n\r\t\v\x00"
-	} else {
-		// If `chars` is a string, use it as the character set.
-		// Otherwise, set an empty string as the character set.
-		switch v := chars[0].(type) {
-		case string:
-			charSet = v
-		default:
-			charSet = ""
-		}
-	}
+func Trim(value any) any {
+	var charSet = " \n\r\t\v\x00"
 
 	// Handle different types of value
 	switch v := value.(type) {

--- a/trim_test.go
+++ b/trim_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"strings"
 	"testing"
 )
 
@@ -128,34 +127,6 @@ func ExampleTrim_otherTypes() {
 	//	<h1>hello world   </h1>
 	//</header>
 	// <nil>
-}
-
-func ExampleTrim_setCutset() {
-	// Trim with cutset is null
-	fmt.Println(strings.ReplaceAll(Trim("  \ttesting trim  ", nil).(string), " ", "[SPACE]"))
-
-	// Trim with cutset is true
-	fmt.Println(strings.ReplaceAll(Trim("  \ttesting trim ", true).(string), " ", "[SPACE]"))
-
-	// Trim with cutset is empty string
-	fmt.Println(strings.ReplaceAll(Trim("\ttesting trim", "").(string), " ", "[SPACE]"))
-
-	// Trim string with no white space
-	fmt.Println(Trim("!===Hello World===!", "=!"))
-
-	// Trim string with embedded null
-	fmt.Println(strings.ReplaceAll(Trim("\\x0n1234\x0005678\x0000efgh\\xijkl\\x0n1", "\\x0n1").(string), "\x00", "[NULL]"))
-
-	// Trim string with default characters
-	fmt.Println(strings.ReplaceAll(Trim(" \x00\t\nABC \x00\t\n", "").(string), "\x00\t\n", "[NULL][TAB][NEWLINE]"))
-
-	// Output:
-	// [SPACE][SPACE]	testing[SPACE]trim[SPACE][SPACE]
-	// [SPACE][SPACE]	testing[SPACE]trim[SPACE]
-	// 	testing[SPACE]trim
-	// Hello World
-	// 234[NULL]05678[NULL]00efgh\xijkl
-	//  [NULL][TAB][NEWLINE]ABC [NULL][TAB][NEWLINE]
 }
 
 func TestTrim(t *testing.T) {
@@ -305,65 +276,4 @@ func TestTrim(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestTrimWithCutset(t *testing.T) {
-	testCase := []struct {
-		testName string
-		input    interface{}
-		cutset   interface{}
-		expected interface{}
-	}{
-		{
-			testName: "cutsetIsNull",
-			input:    "  \ttesting trim ",
-			cutset:   nil,
-			expected: "  \ttesting trim ",
-		},
-		{
-			testName: "cutsetIsTrue",
-			input:    "  \ttesting trim ",
-			cutset:   true,
-			expected: "  \ttesting trim ",
-		},
-		{
-			testName: "cutsetIsEmptyString",
-			input:    "\ttesting trim",
-			cutset:   "",
-			expected: "\ttesting trim",
-		},
-		{
-			testName: "StringWithEmbeddedNull",
-			input:    "\\x0n1234\x0005678\x0000efgh\\xijkl\\x0n1",
-			cutset:   "\\x0n1",
-			expected: "234\x0005678\x0000efgh\\xijkl",
-		},
-		{
-			testName: "StringWithDefaultCharacters",
-			input:    " \x00\t\nABC \x00\t\n",
-			cutset:   "",
-			expected: " \x00\t\nABC \x00\t\n",
-		},
-		{
-			testName: "StringWithNoWhitespace",
-			input:    "!===Hello World===!",
-			cutset:   "=!",
-			expected: "Hello World",
-		},
-		{
-			testName: "cutsetIsRangeWithASCIICode",
-			input:    "abcdefghi",
-			cutset:   "a..f",
-			expected: "bcdefghi",
-		},
-	}
-	for _, tc := range testCase {
-		t.Run(tc.testName, func(t *testing.T) {
-			result := Trim(tc.input, tc.cutset)
-			if !reflect.DeepEqual(result, tc.expected) {
-				t.Errorf("%s: expected %v, bug got %v", tc.testName, tc.expected, result)
-			}
-		})
-	}
-
 }


### PR DESCRIPTION
Add a ported function that works exactly the same as PHP 5.6's trim function

In PHP 5.6, when attempting to use the trim() function with a data type other than a string,
it automatically converts the requested variable into a string before performing the trim.
To achieve the same behavior in Go, this function converts the requested data types into strings
and then utilize the trim function from the package strings.
For more detailed information about the trim function in the package strings, see the [strings's trim documentation]

Reference:

- https://www.php.net/manual/en/function.trim.php
- https://github.com/php/php-src/blob/4b8f72da5dfb201af4e82dee960261d8657e414f/ext/standard/string.c#L840-L850
- https://github.com/php/php-src/blob/4b8f72da5dfb201af4e82dee960261d8657e414f/Zend/zend_API.c#L425-L470
- https://github.com/php/php-src/blob/4b8f72da5dfb201af4e82dee960261d8657e414f/Zend/zend_operators.c#L593-L661
- https://github.com/php/php-src/blob/4b8f72da5dfb201af4e82dee960261d8657e414f/Zend/zend_API.c#L261-L302

Test Cases:

- https://github.com/php/php-src/blob/php-5.6.40/ext/standard/tests/strings/trim1.phpt
- https://github.com/php/php-src/blob/php-5.6.40/ext/standard/tests/strings/trim.phpt
- https://github.com/php/php-src/blob/php-5.6.40/ext/standard/tests/strings/trim_basic.phpt
- https://github.com/php/php-src/blob/php-5.6.40/ext/standard/tests/strings/trim_variation1.phpt

NOTE: This function does not support specifying a set of characters using string ranges (e.g., "a-z") in the chars parameter.

