### PR TITLE
Implement ZendParseArg and Ord function

### DIFF
--- a/ord.go
+++ b/ord.go
@@ -1,0 +1,38 @@
+package gophplib
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Ord is a ported functions that works exactly the same as PHP 5.6's ord function.
+// In PHP 5.6, when the ord() function is used with a data type other
+// than a string, it automatically converts the given variable into a string
+// before processing it. To achieve the same behavior in Go,
+// this function converts an argument to string using the ZendParseArgImpl() function.
+// For more information, see the [official PHP documentation].
+//
+// Reference :
+//   - https://github.com/php/php-src/blob/php-5.6.40/ext/standard/string.c#L2666-L2676
+//
+// Test Cases:
+//   - https://github.com/php/php-src/blob/php-5.6.40/ext/standard/tests/strings/ord_basic.phpt
+//   - https://github.com/php/php-src/blob/php-5.6.40/ext/standard/tests/strings/ord_error.phpt
+//   - https://github.com/php/php-src/blob/php-5.6.40/ext/standard/tests/strings/ord_variation1.phpt
+//
+// [official PHP documentation]: https://www.php.net/manual/en/function.ord.php
+func Ord(character any) (byte, error) {
+	// Convert a character to string
+	characterString, err := ZendParseArgImpl(character)
+	if err != nil {
+		return 0, fmt.Errorf("unsupported type : %s", reflect.TypeOf(character))
+	}
+
+	// Check if the characterString is not empty
+	if len(characterString) > 0 {
+		// Return the first byte of input argument's string representation
+		return []byte(characterString)[0], nil
+	}
+	// Return for empty strings
+	return 0, nil
+}

--- a/ord.go
+++ b/ord.go
@@ -9,7 +9,7 @@ import (
 // In PHP 5.6, when the ord() function is used with a data type other
 // than a string, it automatically converts the given variable into a string
 // before processing it. To achieve the same behavior in Go,
-// this function converts an argument to string using the ZendParseArgImpl() function.
+// this function converts an argument to string using the zendParseArgAsString() function.
 // For more information, see the [official PHP documentation].
 //
 // Reference :
@@ -23,7 +23,7 @@ import (
 // [official PHP documentation]: https://www.php.net/manual/en/function.ord.php
 func Ord(character any) (byte, error) {
 	// Convert a character to string
-	characterString, err := ZendParseArgImpl(character)
+	characterString, err := zendParseArgAsString(character)
 	if err != nil {
 		return 0, fmt.Errorf("unsupported type : %s", reflect.TypeOf(character))
 	}

--- a/ord_test.go
+++ b/ord_test.go
@@ -1,0 +1,150 @@
+package gophplib
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+var unsetVariable string
+
+func ExampleOrd() {
+	// Plain char
+	fmt.Println(Ord("a"))
+
+	// Plain string
+	fmt.Println(Ord("Hello"))
+
+	// Special character
+	fmt.Println(Ord("!"))
+
+	// New line character
+	fmt.Println(Ord("\n"))
+
+	// Hexadecimal representation of newline character
+	fmt.Println(Ord("\x0A"))
+
+	// Character '0'
+	fmt.Println(Ord("0"))
+
+	// Emoji
+	fmt.Println(Ord("🐘"))
+
+	// 한글
+	fmt.Println(Ord("안녕하세요"))
+
+	// Output:
+	// 97 <nil>
+	// 72 <nil>
+	// 33 <nil>
+	// 10 <nil>
+	// 10 <nil>
+	// 48 <nil>
+	// 240 <nil>
+	// 236 <nil>
+}
+
+func ExampleOrd_variation() {
+	// Array
+	fmt.Println(Ord([]int{1}))
+
+	// Nil
+	fmt.Println(Ord(nil))
+
+	// Empty string
+	fmt.Println(Ord(""))
+
+	// Unset variable
+	fmt.Println(Ord(unsetVariable))
+
+	// Output:
+	// 0 unsupported type : []int
+	// 0 <nil>
+	// 0 <nil>
+	// 0 <nil>
+}
+
+func TestOrd(t *testing.T) {
+	testCases := []struct {
+		testName string
+		input    any
+		expected byte
+	}{
+		{
+			testName: "Plain char",
+			input:    "a",
+			expected: 97,
+		},
+		{
+			testName: "Plain string",
+			input:    "Hello",
+			expected: 72,
+		},
+		{
+			testName: "Special character",
+			input:    "!",
+			expected: 33,
+		},
+		{
+			testName: "New line character",
+			input:    "\n",
+			expected: 10,
+		},
+		{
+			testName: "Hexadecimal representation of newline character",
+			input:    "\x0A",
+			expected: 10,
+		},
+		{
+			testName: "Hexadecimal representation of newline character",
+			input:    "\x0A",
+			expected: 10,
+		},
+		{
+			testName: "Character '0'",
+			input:    "0",
+			expected: 48,
+		},
+		{
+			testName: "Array",
+			input:    []int{1},
+			expected: 0,
+		},
+		{
+			testName: "Nil",
+			input:    nil,
+			expected: 0,
+		},
+		{
+			testName: "Empty string",
+			input:    "",
+			expected: 0,
+		},
+		{
+			testName: "Unset variable",
+			input:    unsetVariable,
+			expected: 0,
+		},
+		{
+			testName: "Emoji",
+			input:    "🐘",
+			expected: 240,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			result, err := Ord(tc.input)
+			if err != nil {
+				expectedErr := fmt.Errorf("unsupported type : %s", reflect.TypeOf(tc.input))
+				if err.Error() != expectedErr.Error() {
+					t.Errorf("%s: expected error : %s, got %s", tc.testName, expectedErr, err)
+				}
+			} else {
+				if !reflect.DeepEqual(result, tc.expected) {
+					t.Errorf("%s: expected %v, got %v", tc.testName, tc.expected, result)
+				}
+			}
+		})
+	}
+}

--- a/trim.go
+++ b/trim.go
@@ -5,10 +5,6 @@ import (
 	"strings"
 )
 
-type toStringAble interface {
-	toString() string
-}
-
 // Trim is a ported function that works exactly the same as PHP 5.6's trim
 // function. For more information, see the [official PHP documentation].
 //

--- a/zend_parse_arg_impl.go
+++ b/zend_parse_arg_impl.go
@@ -1,0 +1,75 @@
+package gophplib
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+)
+
+type toStringAble interface {
+	toString() string
+}
+
+// floatToString converts a float64 to a string based on the PHP 5.6 rules.
+//   - Allows up to a maximum of 14 digits, including both integer and decimal places.
+//   - Remove trailing zeros from the fractional part
+//     ex) 123.4000 → "123.4"
+//   - Keep the values as is if the last digit is not 0.
+//     ex) 123.45 → "123.45"
+//   - If the integer part exceeds 14 digits, use exponential notation.
+//     ex) 123456789123456.40 → "1.2345678901234e+14"
+//   - If the total number of digits exceeds 14, truncate the decimal places.
+//     ex) 123.45678901234 → "123.4567890123"
+//
+// Reference :
+//   - https://github.com/php/php-src/blob/php-5.6.40/Zend/zend_operators.c#L627-L633
+func floatToString(value float64) string {
+	if math.IsNaN(value) {
+		return "NAN"
+	}
+	if math.IsInf(value, 1) {
+		return "INF"
+	}
+	if math.IsInf(value, -1) {
+		return "-INF"
+	}
+	return fmt.Sprintf("%.*G", 14, value)
+}
+
+// ZendParseArgImpl attempts to replicate the behavior of the 'zend_parse_arg_impl' function
+// from PHP 5.6, specifically for the case where the 'spec' parameter is "s".
+// It handles conversion of different types to string in a way that aligns with PHP's type juggling rules.
+//
+// Reference :
+//   - https://github.com/php/php-src/blob/php-5.6.40/Zend/zend_API.c#L685-L713
+//   - https://github.com/php/php-src/blob/php-5.6.40/Zend/zend_API.c#L425-L470
+//   - https://github.com/php/php-src/blob/php-5.6.40/Zend/zend_operators.c#L593-L661
+//   - https://github.com/php/php-src/blob/php-5.6.40/Zend/zend_API.c#L261-L301
+func ZendParseArgImpl(value any) (string, error) {
+	var str string
+
+	switch v := value.(type) {
+	case string:
+		str = v
+	case int, int64:
+		str = fmt.Sprintf("%v", v)
+	case float64:
+		str = floatToString(v)
+	case bool:
+		// return "1" for true and an empty string("") for false
+		if v {
+			str = "1"
+		} else {
+			str = ""
+		}
+	case nil:
+		// TODO: handle check_null
+		str = ""
+	case toStringAble:
+		// For types implementing toString(), get the value of toString()
+		str = v.toString()
+	default:
+		return "", fmt.Errorf("unsupported type : %s", reflect.TypeOf(v))
+	}
+	return str, nil
+}

--- a/zend_parse_arg_impl.go
+++ b/zend_parse_arg_impl.go
@@ -36,7 +36,7 @@ func floatToString(value float64) string {
 	return fmt.Sprintf("%.*G", 14, value)
 }
 
-// ZendParseArgImpl attempts to replicate the behavior of the 'zend_parse_arg_impl' function
+// zendParseArgAsString attempts to replicate the behavior of the 'zend_parse_arg_impl' function
 // from PHP 5.6, specifically for the case where the 'spec' parameter is "s".
 // It handles conversion of different types to string in a way that aligns with PHP's type juggling rules.
 //
@@ -45,7 +45,7 @@ func floatToString(value float64) string {
 //   - https://github.com/php/php-src/blob/php-5.6.40/Zend/zend_API.c#L425-L470
 //   - https://github.com/php/php-src/blob/php-5.6.40/Zend/zend_operators.c#L593-L661
 //   - https://github.com/php/php-src/blob/php-5.6.40/Zend/zend_API.c#L261-L301
-func ZendParseArgImpl(value any) (string, error) {
+func zendParseArgAsString(value any) (string, error) {
 	var str string
 
 	switch v := value.(type) {

--- a/zend_parse_arg_impl_test.go
+++ b/zend_parse_arg_impl_test.go
@@ -20,125 +20,7 @@ func (s Sample) toString() string {
 	return "sample object"
 }
 
-func ExampleZendParseArgImpl() {
-	// Plain string
-	fmt.Println(ZendParseArgImpl("Hello world"))
-
-	// Empty string
-	fmt.Println(ZendParseArgImpl(""))
-
-	// String with special characters
-	fmt.Println(ZendParseArgImpl("Line1\\nLine2\\tTab"))
-
-	// Int
-	var myInt int = 123
-	fmt.Println(ZendParseArgImpl(myInt))
-
-	// Int64
-	var myInt64 int64 = 9223372036854775807
-	fmt.Println(ZendParseArgImpl(myInt64))
-
-	// Negative int
-	myInt = -123
-	fmt.Println(ZendParseArgImpl(myInt))
-
-	// Float64
-	var myFloat64 float64 = 123.456
-	fmt.Println(ZendParseArgImpl(myFloat64))
-
-	// Float64 exceeds 14 digits
-	myFloat64 = 123.456789012345678
-	fmt.Println(ZendParseArgImpl(myFloat64))
-
-	// Exponent
-	var myExponent = 10.1234567e10
-	fmt.Println(ZendParseArgImpl(myExponent))
-
-	// Special float - NaN
-	var myNan = math.NaN()
-	fmt.Println(ZendParseArgImpl(myNan))
-
-	// Special float - positive infinity
-	var myInf = math.Inf(1)
-	fmt.Println(ZendParseArgImpl(myInf))
-
-	// Special float - negative infinity
-	myInf = math.Inf(-1)
-	fmt.Println(ZendParseArgImpl(myInf))
-
-	// Negative float64
-	myFloat64 = -123.456
-	fmt.Println(ZendParseArgImpl(myFloat64))
-
-	// Zero float
-	myFloat64 = 0.0
-	fmt.Println(ZendParseArgImpl(myFloat64))
-
-	// True
-	var myTrue = true
-	fmt.Println(ZendParseArgImpl(myTrue))
-
-	// False
-	var myFalse = false
-	fmt.Println(ZendParseArgImpl(myFalse))
-
-	// Nil
-	fmt.Println(ZendParseArgImpl(nil))
-
-	// Object with toString function
-	var myObject = Sample{}
-	fmt.Println(ZendParseArgImpl(myObject))
-
-	// Object without toString function
-	var myObject2 = Sample2{}
-	fmt.Println(ZendParseArgImpl(myObject2))
-
-	// Int Array
-	var myArray []int = []int{1, 2, 3}
-	fmt.Println(ZendParseArgImpl(myArray))
-
-	// String array
-	var myArray2 = []string{"hello", "world"}
-	fmt.Println(ZendParseArgImpl(myArray2))
-
-	// Resource
-	file, osErr := os.Open("README.md")
-	if osErr != nil {
-		panic(osErr)
-	}
-	fmt.Println(ZendParseArgImpl(file))
-
-	// Custom type
-	var myCustom CustomType = CustomType{"Hello world"}
-	fmt.Println(ZendParseArgImpl(myCustom))
-
-	// Output:
-	// Hello world <nil>
-	//  <nil>
-	// Line1\nLine2\tTab <nil>
-	// 123 <nil>
-	// 9223372036854775807 <nil>
-	// -123 <nil>
-	// 123.456 <nil>
-	// 123.45678901235 <nil>
-	// 101234567000 <nil>
-	// NAN <nil>
-	// INF <nil>
-	// -INF <nil>
-	// -123.456 <nil>
-	// 0 <nil>
-	// 1 <nil>
-	//  <nil>
-	//  <nil>
-	// sample object <nil>
-	// <nil> unsupported type : gophplib.Sample2
-	// <nil> unsupported type : []int
-	// <nil> unsupported type : []string
-	// <nil> unsupported type : *os.File
-	// <nil> unsupported type : gophplib.CustomType
-}
-
-func TestZendParseArgImpl(t *testing.T) {
+func TestZendParseArgAsString(t *testing.T) {
 	file, osErr := os.Open("README.md")
 	if osErr != nil {
 		panic(osErr)
@@ -276,7 +158,7 @@ func TestZendParseArgImpl(t *testing.T) {
 	}
 	for _, tc := range testCase {
 		t.Run(tc.testName, func(t *testing.T) {
-			result, err := ZendParseArgImpl(tc.input)
+			result, err := zendParseArgAsString(tc.input)
 			if err != nil {
 				expectedErr := fmt.Errorf("unsupported type : %s", reflect.TypeOf(tc.input))
 				if err.Error() != expectedErr.Error() {

--- a/zend_parse_arg_impl_test.go
+++ b/zend_parse_arg_impl_test.go
@@ -1,0 +1,292 @@
+package gophplib
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"reflect"
+	"testing"
+)
+
+type Sample struct{}
+
+type Sample2 struct{}
+
+type CustomType struct {
+	value string
+}
+
+func (s Sample) toString() string {
+	return "sample object"
+}
+
+func ExampleZendParseArgImpl() {
+	// Plain string
+	fmt.Println(ZendParseArgImpl("Hello world"))
+
+	// Empty string
+	fmt.Println(ZendParseArgImpl(""))
+
+	// String with special characters
+	fmt.Println(ZendParseArgImpl("Line1\\nLine2\\tTab"))
+
+	// Int
+	var myInt int = 123
+	fmt.Println(ZendParseArgImpl(myInt))
+
+	// Int64
+	var myInt64 int64 = 9223372036854775807
+	fmt.Println(ZendParseArgImpl(myInt64))
+
+	// Negative int
+	myInt = -123
+	fmt.Println(ZendParseArgImpl(myInt))
+
+	// Float64
+	var myFloat64 float64 = 123.456
+	fmt.Println(ZendParseArgImpl(myFloat64))
+
+	// Float64 exceeds 14 digits
+	myFloat64 = 123.456789012345678
+	fmt.Println(ZendParseArgImpl(myFloat64))
+
+	// Exponent
+	var myExponent = 10.1234567e10
+	fmt.Println(ZendParseArgImpl(myExponent))
+
+	// Special float - NaN
+	var myNan = math.NaN()
+	fmt.Println(ZendParseArgImpl(myNan))
+
+	// Special float - positive infinity
+	var myInf = math.Inf(1)
+	fmt.Println(ZendParseArgImpl(myInf))
+
+	// Special float - negative infinity
+	myInf = math.Inf(-1)
+	fmt.Println(ZendParseArgImpl(myInf))
+
+	// Negative float64
+	myFloat64 = -123.456
+	fmt.Println(ZendParseArgImpl(myFloat64))
+
+	// Zero float
+	myFloat64 = 0.0
+	fmt.Println(ZendParseArgImpl(myFloat64))
+
+	// True
+	var myTrue = true
+	fmt.Println(ZendParseArgImpl(myTrue))
+
+	// False
+	var myFalse = false
+	fmt.Println(ZendParseArgImpl(myFalse))
+
+	// Nil
+	fmt.Println(ZendParseArgImpl(nil))
+
+	// Object with toString function
+	var myObject = Sample{}
+	fmt.Println(ZendParseArgImpl(myObject))
+
+	// Object without toString function
+	var myObject2 = Sample2{}
+	fmt.Println(ZendParseArgImpl(myObject2))
+
+	// Int Array
+	var myArray []int = []int{1, 2, 3}
+	fmt.Println(ZendParseArgImpl(myArray))
+
+	// String array
+	var myArray2 = []string{"hello", "world"}
+	fmt.Println(ZendParseArgImpl(myArray2))
+
+	// Resource
+	file, osErr := os.Open("README.md")
+	if osErr != nil {
+		panic(osErr)
+	}
+	fmt.Println(ZendParseArgImpl(file))
+
+	// Custom type
+	var myCustom CustomType = CustomType{"Hello world"}
+	fmt.Println(ZendParseArgImpl(myCustom))
+
+	// Output:
+	// Hello world <nil>
+	//  <nil>
+	// Line1\nLine2\tTab <nil>
+	// 123 <nil>
+	// 9223372036854775807 <nil>
+	// -123 <nil>
+	// 123.456 <nil>
+	// 123.45678901235 <nil>
+	// 101234567000 <nil>
+	// NAN <nil>
+	// INF <nil>
+	// -INF <nil>
+	// -123.456 <nil>
+	// 0 <nil>
+	// 1 <nil>
+	//  <nil>
+	//  <nil>
+	// sample object <nil>
+	// <nil> unsupported type : gophplib.Sample2
+	// <nil> unsupported type : []int
+	// <nil> unsupported type : []string
+	// <nil> unsupported type : *os.File
+	// <nil> unsupported type : gophplib.CustomType
+}
+
+func TestZendParseArgImpl(t *testing.T) {
+	file, osErr := os.Open("README.md")
+	if osErr != nil {
+		panic(osErr)
+	}
+
+	testCase := []struct {
+		testName string
+		input    any
+		expected string
+	}{
+		{
+			testName: "Plain string",
+			input:    "Hello world",
+			expected: "Hello world",
+		},
+		{
+			testName: "Empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			testName: "StringWithSpecialChars",
+			input:    "Line1\nLine2\tTab",
+			expected: "Line1\nLine2\tTab",
+		},
+		{
+			testName: "Int",
+			input:    123,
+			expected: "123",
+		},
+		{
+			testName: "Int64",
+			input:    9223372036854775807,
+			expected: "9223372036854775807",
+		},
+		{
+			testName: "Negative int",
+			input:    -123,
+			expected: "-123",
+		},
+		{
+			testName: "Float64",
+			input:    123.456,
+			expected: "123.456",
+		},
+		{
+			testName: "Float64 exceeds 14 digits",
+			input:    123.456789012345678,
+			expected: "123.45678901235",
+		},
+		{
+			testName: "Exponent",
+			input:    10.1234567e10,
+			expected: "101234567000",
+		},
+		{
+			testName: "Special Float - NaN",
+			input:    math.NaN(),
+			expected: "NAN",
+		},
+		{
+			testName: "Special float - positive infinity",
+			input:    math.Inf(1),
+			expected: "INF",
+		}, {
+			testName: "Special float - negative infinity",
+			input:    math.Inf(-1),
+			expected: "-INF",
+		},
+		{
+			testName: "Exponent",
+			input:    10.1234567e10,
+			expected: "101234567000",
+		},
+		{
+			testName: "Negative float64",
+			input:    -123.456,
+			expected: "-123.456",
+		},
+		{
+			testName: "Zero float64",
+			input:    0.0,
+			expected: "0",
+		},
+		{
+			testName: "True",
+			input:    true,
+			expected: "1",
+		},
+		{
+			testName: "False",
+			input:    false,
+			expected: "",
+		},
+		{
+			testName: "Nil",
+			input:    nil,
+			expected: "",
+		},
+		{
+			testName: "Object with toString function",
+			input:    Sample{},
+			expected: "sample object",
+		},
+		{
+			testName: "Object without toString function",
+			input:    Sample2{},
+			expected: "",
+		},
+		{
+			testName: "Int array",
+			input:    []int{1, 2, 3},
+			expected: "",
+		},
+		{
+			testName: "String array",
+			input:    []string{"hello", "world"},
+			expected: "",
+		},
+		{
+			testName: "NestedArray",
+			input:    []interface{}{[]interface{}{1, 2}, []interface{}{"a", "b"}},
+			expected: "",
+		},
+		{
+			testName: "Resource",
+			input:    file,
+			expected: "",
+		},
+		{
+			testName: "Custom type",
+			input:    CustomType{"Hello world"},
+			expected: "",
+		},
+	}
+	for _, tc := range testCase {
+		t.Run(tc.testName, func(t *testing.T) {
+			result, err := ZendParseArgImpl(tc.input)
+			if err != nil {
+				expectedErr := fmt.Errorf("unsupported type : %s", reflect.TypeOf(tc.input))
+				if err.Error() != expectedErr.Error() {
+					t.Errorf("%s: expected error : %s, got %s", tc.testName, expectedErr, err)
+				}
+			} else {
+				if !reflect.DeepEqual(result, tc.expected) {
+					t.Errorf("%s: expected %v, got %v", tc.testName, tc.expected, result)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
* Add ZendParseArg function that attempts to replicate the behavior of the 'zend_parse_arg_impl' function
 from PHP 5.6, specifically for the case where the "spec" parameter is "s".
* Add Ord function that works exactly the same as PHP 5.6's ord function using ZendParseArg function

## Reference
### ZendParseArg 
- https://github.com/php/php-src/blob/php-5.6.40/Zend/zend_operators.c#L593-L661
- https://github.com/php/php-src/blob/php-5.6.40/Zend/zend_operators.c#L593-L661
- https://github.com/php/php-src/blob/4b8f72da5dfb201af4e82dee960261d8657e414f/Zend/zend_API.c#L261-L301
- https://github.com/php/php-src/blob/4b8f72da5dfb201af4e82dee960261d8657e414f/Zend/zend_operators.c#L627-L633
### Ord
- https://github.com/php/php-src/blob/php-5.6.40/ext/standard/string.c#L2666-L2676