### PR TITLE
Refactor test cases to use anonymous fields in structs

### DIFF
--- a/ord_test.go
+++ b/ord_test.go
@@ -66,83 +66,35 @@ func ExampleOrd_variation() {
 
 func TestOrd(t *testing.T) {
 	testCases := []struct {
-		testName string
-		input    any
-		expected byte
+		any
+		byte
 	}{
-		{
-			testName: "Plain char",
-			input:    "a",
-			expected: 97,
-		},
-		{
-			testName: "Plain string",
-			input:    "Hello",
-			expected: 72,
-		},
-		{
-			testName: "Special character",
-			input:    "!",
-			expected: 33,
-		},
-		{
-			testName: "New line character",
-			input:    "\n",
-			expected: 10,
-		},
-		{
-			testName: "Hexadecimal representation of newline character",
-			input:    "\x0A",
-			expected: 10,
-		},
-		{
-			testName: "Hexadecimal representation of newline character",
-			input:    "\x0A",
-			expected: 10,
-		},
-		{
-			testName: "Character '0'",
-			input:    "0",
-			expected: 48,
-		},
-		{
-			testName: "Array",
-			input:    []int{1},
-			expected: 0,
-		},
-		{
-			testName: "Nil",
-			input:    nil,
-			expected: 0,
-		},
-		{
-			testName: "Empty string",
-			input:    "",
-			expected: 0,
-		},
-		{
-			testName: "Unset variable",
-			input:    unsetVariable,
-			expected: 0,
-		},
-		{
-			testName: "Emoji",
-			input:    "🐘",
-			expected: 240,
-		},
+		{"a", 97},
+		{"Hello", 72},
+		{"!", 33},
+		{"\n", 10},
+		{"\x0A", 10},
+		{"\x0A", 10},
+		{"0", 48},
+		{[]int{1}, 0},
+		{nil, 0},
+		{"", 0},
+		{unsetVariable, 0},
+		{"🐘", 240},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.testName, func(t *testing.T) {
-			result, err := Ord(tc.input)
+		testName := fmt.Sprintf("%v", tc.any)
+		t.Run(testName, func(t *testing.T) {
+			result, err := Ord(tc.any)
 			if err != nil {
-				expectedErr := fmt.Errorf("unsupported type : %s", reflect.TypeOf(tc.input))
-				if err.Error() != expectedErr.Error() {
-					t.Errorf("%s: expected error : %s, got %s", tc.testName, expectedErr, err)
+				byteErr := fmt.Errorf("unsupported type : %s", reflect.TypeOf(tc.any))
+				if err.Error() != byteErr.Error() {
+					t.Errorf("%s: byte error : %s, got %s", testName, byteErr, err)
 				}
 			} else {
-				if !reflect.DeepEqual(result, tc.expected) {
-					t.Errorf("%s: expected %v, got %v", tc.testName, tc.expected, result)
+				if !reflect.DeepEqual(result, tc.byte) {
+					t.Errorf("%s: byte %v, got %v", testName, tc.byte, result)
 				}
 			}
 		})

--- a/trim_test.go
+++ b/trim_test.go
@@ -146,150 +146,59 @@ func TestTrim(t *testing.T) {
 
 	// Successful cases
 	testCase := []struct {
-		testName string
-		input    any
-		expected any
+		any
+		string
 	}{
-		{
-			testName: "BasicTest",
-			input:    "Hello world ",
-			expected: "Hello world",
-		},
-		{
-			testName: "EmptyString",
-			input:    "",
-			expected: "",
-		},
-		{
-			testName: "Integer",
-			input:    123,
-			expected: "123",
-		},
-		{
-			testName: "NegativeInteger",
-			input:    -123,
-			expected: "-123",
-		},
-		{
-			testName: "Zero",
-			input:    0,
-			expected: "0",
-		},
-		{
-			testName: "True",
-			input:    true,
-			expected: "1",
-		},
-		{
-			testName: "False",
-			input:    false,
-			expected: "",
-		},
-		{
-			testName: "Nil",
-			input:    nil,
-			expected: "",
-		},
-		{
-			testName: "Float",
-			input:    123.40,
-			expected: "123.4",
-		},
-		{
-			testName: "NegativeFloat",
-			input:    -123.40,
-			expected: "-123.4",
-		},
-		{
-			testName: "Exponent",
-			input:    10.1234567e10,
-			expected: "101234567000",
-		},
-		{
-			testName: "FloatExceeds14Digits",
-			input:    1230.12984732591475609346509132875091237,
-			expected: "1230.1298473259",
-		},
-		{
-			testName: "FloatEndsWith0",
-			input:    1230.12984732500000000000000000000000000,
-			expected: "1230.129847325",
-		},
-		{
-			testName: "IntegerExceeds14Digits",
-			input:    123456789123456.40,
-			expected: "1.2345678912346E+14",
-		},
-		{
-			testName: "IntegerEndsWith0",
-			input:    12345678912340.40,
-			expected: "12345678912340",
-		},
-		{
-			testName: "ObjectHasToString",
-			input:    c,
-			expected: c.toString(),
-		},
-		{
-			testName: "Function",
-			input:    customTrim(nil),
-			expected: "hello world",
-		},
-		{
-			testName: "HereDocuments",
-			input: `<header>
+		{"Hello world ", "Hello world"},
+		{"", ""},
+		{123, "123"},
+		{-123, "-123"},
+		{0, "0"},
+		{true, "1"},
+		{false, ""},
+		{nil, ""},
+		{123.40, "123.4"},
+		{-123.40, "-123.4"},
+		{10.1234567e10, "101234567000"},
+		{1230.12984732591475609346509132875091237, "1230.1298473259"},
+		{1230.12984732500000000000000000000000000, "1230.129847325"},
+		{123456789123456.40, "1.2345678912346E+14"},
+		{12345678912340.40, "12345678912340"},
+		{c, c.toString()},
+		{customTrim(nil), "hello world"},
+		{`<header>
 	<h1>hello world   </h1>
-</header>`,
-			expected: "<header>\n\t<h1>hello world   </h1>\n</header>",
-		},
-		{
-			testName: "StringWithDefaultCharacters",
-			input:    " \x00\t\nABC \x00\t\n",
-			expected: "ABC",
-		},
+</header>`, "<header>\n\t<h1>hello world   </h1>\n</header>"},
+		{" \x00\t\nABC \x00\t\n", "ABC"},
 	}
 
 	for _, tc := range testCase {
-		t.Run(tc.testName, func(t *testing.T) {
-			result, err := Trim(tc.input)
+		testName := fmt.Sprintf("%v", tc.any)
+		t.Run(testName, func(t *testing.T) {
+			result, err := Trim(tc.any)
 			if err != nil {
-				t.Errorf("%s: expected success, bug got error %v", tc.testName, err)
+				t.Errorf("%s: string success, bug got error %v", testName, err)
 			}
-			if !reflect.DeepEqual(result, tc.expected) {
-				t.Errorf("%s: expected %v, bug got %v", tc.testName, tc.expected, result)
+			if !reflect.DeepEqual(result, tc.string) {
+				t.Errorf("%s: string %v, bug got %v", testName, tc.string, result)
 			}
 		})
 	}
 
 	// Failing cases
-	errorCase := []struct {
-		testName string
-		input    any
-		expected any
-	}{
-		{
-			testName: "EmptyArray",
-			input:    []any{},
-		},
-		{
-			testName: "Array",
-			input:    []any{"foo", "456", 7},
-		},
-		{
-			testName: "ObjectWithoutToString",
-			input:    d,
-		},
-		{
-			testName: "Resource",
-			input:    file,
-		},
+	errorCase := []any{
+		[]any{},
+		[]any{"foo", "456", 7},
+		d,
+		file,
 	}
 
 	for _, tc := range errorCase {
-		t.Run(tc.testName, func(t *testing.T) {
-			result, err := Trim(tc.input)
+		testName := fmt.Sprintf("%v", tc)
+		t.Run(testName, func(t *testing.T) {
+			result, err := Trim(tc)
 			if err == nil {
-				t.Errorf("%s: expected error, bug got %v", tc.testName, result)
+				t.Errorf("%s:  error, bug got %v", testName, result)
 			}
 		})
 	}

--- a/zend_parse_arg_impl_test.go
+++ b/zend_parse_arg_impl_test.go
@@ -27,146 +27,47 @@ func TestZendParseArgAsString(t *testing.T) {
 	}
 
 	testCase := []struct {
-		testName string
-		input    any
-		expected string
+		any
+		string
 	}{
-		{
-			testName: "Plain string",
-			input:    "Hello world",
-			expected: "Hello world",
-		},
-		{
-			testName: "Empty string",
-			input:    "",
-			expected: "",
-		},
-		{
-			testName: "StringWithSpecialChars",
-			input:    "Line1\nLine2\tTab",
-			expected: "Line1\nLine2\tTab",
-		},
-		{
-			testName: "Int",
-			input:    123,
-			expected: "123",
-		},
-		{
-			testName: "Int64",
-			input:    9223372036854775807,
-			expected: "9223372036854775807",
-		},
-		{
-			testName: "Negative int",
-			input:    -123,
-			expected: "-123",
-		},
-		{
-			testName: "Float64",
-			input:    123.456,
-			expected: "123.456",
-		},
-		{
-			testName: "Float64 exceeds 14 digits",
-			input:    123.456789012345678,
-			expected: "123.45678901235",
-		},
-		{
-			testName: "Exponent",
-			input:    10.1234567e10,
-			expected: "101234567000",
-		},
-		{
-			testName: "Special Float - NaN",
-			input:    math.NaN(),
-			expected: "NAN",
-		},
-		{
-			testName: "Special float - positive infinity",
-			input:    math.Inf(1),
-			expected: "INF",
-		}, {
-			testName: "Special float - negative infinity",
-			input:    math.Inf(-1),
-			expected: "-INF",
-		},
-		{
-			testName: "Exponent",
-			input:    10.1234567e10,
-			expected: "101234567000",
-		},
-		{
-			testName: "Negative float64",
-			input:    -123.456,
-			expected: "-123.456",
-		},
-		{
-			testName: "Zero float64",
-			input:    0.0,
-			expected: "0",
-		},
-		{
-			testName: "True",
-			input:    true,
-			expected: "1",
-		},
-		{
-			testName: "False",
-			input:    false,
-			expected: "",
-		},
-		{
-			testName: "Nil",
-			input:    nil,
-			expected: "",
-		},
-		{
-			testName: "Object with toString function",
-			input:    Sample{},
-			expected: "sample object",
-		},
-		{
-			testName: "Object without toString function",
-			input:    Sample2{},
-			expected: "",
-		},
-		{
-			testName: "Int array",
-			input:    []int{1, 2, 3},
-			expected: "",
-		},
-		{
-			testName: "String array",
-			input:    []string{"hello", "world"},
-			expected: "",
-		},
-		{
-			testName: "NestedArray",
-			input:    []interface{}{[]interface{}{1, 2}, []interface{}{"a", "b"}},
-			expected: "",
-		},
-		{
-			testName: "Resource",
-			input:    file,
-			expected: "",
-		},
-		{
-			testName: "Custom type",
-			input:    CustomType{"Hello world"},
-			expected: "",
-		},
+		{"Hello world", "Hello world"},
+		{"", ""},
+		{"Line1\nLine2\tTab", "Line1\nLine2\tTab"},
+		{123, "123"},
+		{9223372036854775807, "9223372036854775807"},
+		{-123, "-123"},
+		{123.456, "123.456"},
+		{123.456789012345678, "123.45678901235"},
+		{10.1234567e10, "101234567000"},
+		{math.NaN(), "NAN"},
+		{math.Inf(1), "INF"},
+		{math.Inf(-1), "-INF"},
+		{10.1234567e10, "101234567000"},
+		{-123.456, "-123.456"},
+		{0.0, "0"},
+		{true, "1"},
+		{false, ""},
+		{nil, ""},
+		{Sample{}, "sample object"},
+		{Sample2{}, ""},
+		{[]int{1, 2, 3}, ""},
+		{[]string{"hello", "world"}, ""},
+		{[]interface{}{[]interface{}{1, 2}, []interface{}{"a", "b"}}, ""},
+		{file, ""},
+		{CustomType{"Hello world"}, ""},
 	}
 	for _, tc := range testCase {
-		t.Run(tc.testName, func(t *testing.T) {
-			result, err := zendParseArgAsString(tc.input)
+		testName := fmt.Sprintf("%v", tc.any)
+		t.Run(testName, func(t *testing.T) {
+			result, err := zendParseArgAsString(tc.any)
 			if err != nil {
-				expectedErr := fmt.Errorf("unsupported type : %s", reflect.TypeOf(tc.input))
+				expectedErr := fmt.Errorf("unsupported type : %s", reflect.TypeOf(tc.any))
 				if err.Error() != expectedErr.Error() {
-					t.Errorf("%s: expected error : %s, got %s", tc.testName, expectedErr, err)
+					t.Errorf("%s: expected error : %s, got %s", testName, expectedErr, err)
 				}
 			} else {
-				if !reflect.DeepEqual(result, tc.expected) {
-					t.Errorf("%s: expected %v, got %v", tc.testName, tc.expected, result)
+				if !reflect.DeepEqual(result, tc.string) {
+					t.Errorf("%s: expected %v, got %v", testName, tc.string, result)
 				}
 			}
 		})


### PR DESCRIPTION
For Ord, Trim, zendParseArgAsString function, refactored test cases to use anonymous fields in structs