### PR TITLE
base64_encode.go: Add Base64Encode function and test codes

### DIFF
--- a/base64_encode.go
+++ b/base64_encode.go
@@ -1,0 +1,54 @@
+package gophplib
+
+import (
+	"encoding/base64"
+	"fmt"
+	"math"
+	"reflect"
+)
+
+// Base64Encode emulates the functionality of PHP 5.6's base64_encode function.
+// For more information, see the [official PHP documentation].
+// In PHP 5.6, an error is triggered if the input size is excessively large due to memory limitations.
+// This Go implementation includes similar checks to emulate PHP's memory limitation conditions.
+// Additionally, this function converts different types of variables to a string, following PHP's dynamic typing approach.
+// After ensuring the memory constraints are met and converting the input to a string,
+// it uses the EncodeToString function from the encoding/base64 package to perform the Base64 encoding.
+// The result is a Base64 encoded string, consistent with PHP's output for the same input.
+// For more detailed information about the EncodeToString function in the package encoding/base64,
+// see the [encoding/base64's EncodeToString documentation]
+//
+// PHP references:
+//   - base64_encode definition:
+//     https://github.com/php/php-src/blob/php-5.6.40/ext/standard/base64.c#L224-L241
+//   - base64_encode implementation:
+//     https://github.com/php/php-src/blob/4b8f72da5dfb201af4e82dee960261d8657e414f/ext/standard/base64.c#L56-L106
+//
+// Test Cases :
+//   - https://github.com/php/php-src/blob/php-5.6.40/ext/standard/tests/url/base64_encode_basic_001.phpt
+//   - https://github.com/php/php-src/blob/php-5.6.40/ext/standard/tests/url/base64_encode_basic_002.phpt
+//   - https://github.com/php/php-src/blob/php-5.6.40/ext/standard/tests/url/base64_encode_error_001.phpt
+//   - https://github.com/php/php-src/blob/php-5.6.40/ext/standard/tests/url/base64_encode_variation_001.phpt
+//
+// [official PHP documentation]: https://www.php.net/manual/en/function.base64-encode
+// [encoding/base64's EncodeToString documentation]: https://pkg.go.dev/encoding/base64#Encoding.EncodeToString
+func Base64Encode(value any) (string, error) {
+	// Convert a value to string
+	characterString, err := zendParseArgAsString(value)
+	if err != nil {
+		return "", fmt.Errorf("unsupported type : %s", reflect.TypeOf(value))
+	}
+
+	// Base64 encoding converts 3 bytes into 4 bytes ASCII characters,
+	// and adds padding 2 bytes if the converted data is not a multiple of 3.
+	// In PHP, the base64_encode function includes a memory allocation limit check
+	// to prevent potential overflow issues due to the increase in data size during encoding.
+	// In Go, such checks are generally not required thanks to its robust memory management system.
+	// However, to maintain exact behavioral parity with the PHP implementation,
+	// this function includes memory limit check too.
+	if (len(characterString)+2)/3 > math.MaxInt32/4 {
+		return "", fmt.Errorf("string too long, maximum is %d", math.MaxInt32/4)
+	}
+	encodedString := base64.StdEncoding.EncodeToString([]byte(characterString))
+	return encodedString, nil
+}

--- a/base64_encode.go
+++ b/base64_encode.go
@@ -47,7 +47,7 @@ func Base64Encode(value any) (string, error) {
 	// However, to maintain exact behavioral parity with the PHP implementation,
 	// this function includes memory limit check too.
 	if (len(characterString)+2)/3 > math.MaxInt32/4 {
-		return "", fmt.Errorf("string too long, maximum is %d", math.MaxInt32/4)
+		return "", fmt.Errorf("string too long, maximum is 1610612733")
 	}
 	encodedString := base64.StdEncoding.EncodeToString([]byte(characterString))
 	return encodedString, nil

--- a/base64_encode_test.go
+++ b/base64_encode_test.go
@@ -17,16 +17,8 @@ func ExampleBase64Encode() {
 	fmt.Println(Base64Encode(nil))
 	// Empty string
 	fmt.Println(Base64Encode(""))
-	// Empty array
+	// Empty array: Unsupported type
 	fmt.Println(Base64Encode([]int{}))
-	// Complex string with upper-case letters, numbers, and symbols
-	fmt.Println(Base64Encode("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!%^&*(){}[]"))
-	// String with control characters
-	fmt.Println(Base64Encode("\n\t Line with control characters\r\n"))
-	// String with non-standard characters
-	fmt.Println(Base64Encode("\xC1\xC2\xC3\xC4\xC5\xC6"))
-	// 한글
-	fmt.Println(Base64Encode("안녕하세요"))
 
 	// Output:
 	// SGVsbG8= <nil>
@@ -35,10 +27,6 @@ func ExampleBase64Encode() {
 	//  <nil>
 	//  <nil>
 	//  unsupported type : []int
-	// QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY3ODkwISVeJiooKXt9W10= <nil>
-	// CgkgTGluZSB3aXRoIGNvbnRyb2wgY2hhcmFjdGVycw0K <nil>
-	// wcLDxMXG <nil>
-	// 7JWI64WV7ZWY7IS47JqU <nil>
 }
 
 func TestBase64Encode(t *testing.T) {
@@ -49,6 +37,10 @@ func TestBase64Encode(t *testing.T) {
 		{
 			"Hello",
 			"SGVsbG8=",
+		},
+		{
+			"????>>>>",
+			"Pz8/Pz4+Pj4=",
 		},
 		{
 			123,

--- a/base64_encode_test.go
+++ b/base64_encode_test.go
@@ -105,3 +105,10 @@ func TestBase64Encode(t *testing.T) {
 		})
 	}
 }
+
+func TestHugeBase64Error(t *testing.T) {
+	result, err := Base64Encode(string(make([]byte, 1610612734)))
+	if err == nil || err.Error() != "string too long, maximum is 1610612733" {
+		t.Errorf("Expected error, got (%v, %v)", result, err)
+	}
+}

--- a/base64_encode_test.go
+++ b/base64_encode_test.go
@@ -1,0 +1,107 @@
+package gophplib
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func ExampleBase64Encode() {
+	// Plain string
+	fmt.Println(Base64Encode("Hello"))
+	// Int
+	fmt.Println(Base64Encode(123))
+	// Float
+	fmt.Println(Base64Encode(10.5))
+	// Nil
+	fmt.Println(Base64Encode(nil))
+	// Empty string
+	fmt.Println(Base64Encode(""))
+	// Empty array
+	fmt.Println(Base64Encode([]int{}))
+	// Complex string with upper-case letters, numbers, and symbols
+	fmt.Println(Base64Encode("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!%^&*(){}[]"))
+	// String with control characters
+	fmt.Println(Base64Encode("\n\t Line with control characters\r\n"))
+	// String with non-standard characters
+	fmt.Println(Base64Encode("\xC1\xC2\xC3\xC4\xC5\xC6"))
+	// 한글
+	fmt.Println(Base64Encode("안녕하세요"))
+
+	// Output:
+	// SGVsbG8= <nil>
+	// MTIz <nil>
+	// MTAuNQ== <nil>
+	//  <nil>
+	//  <nil>
+	//  unsupported type : []int
+	// QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY3ODkwISVeJiooKXt9W10= <nil>
+	// CgkgTGluZSB3aXRoIGNvbnRyb2wgY2hhcmFjdGVycw0K <nil>
+	// wcLDxMXG <nil>
+	// 7JWI64WV7ZWY7IS47JqU <nil>
+}
+
+func TestBase64Encode(t *testing.T) {
+	testCases := []struct {
+		any
+		string
+	}{
+		{
+			"Hello",
+			"SGVsbG8=",
+		},
+		{
+			123,
+			"MTIz",
+		},
+		{
+			10.5,
+			"MTAuNQ==",
+		},
+		{
+			nil,
+			"",
+		},
+		{
+			"",
+			"",
+		},
+		{
+			[]int{},
+			"",
+		},
+		{
+			"ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!%^&*(){}[]",
+			"QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY3ODkwISVeJiooKXt9W10=",
+		},
+		{
+			"\n\t Line with control characters\r\n",
+			"CgkgTGluZSB3aXRoIGNvbnRyb2wgY2hhcmFjdGVycw0K",
+		},
+		{
+			"\xC1\xC2\xC3\xC4\xC5\xC6",
+			"wcLDxMXG",
+		},
+		{
+			"안녕하세요",
+			"7JWI64WV7ZWY7IS47JqU",
+		},
+	}
+
+	for _, tc := range testCases {
+		testName := fmt.Sprintf("%v", tc.any)
+		t.Run(testName, func(t *testing.T) {
+			result, err := Base64Encode(tc.any)
+			if err != nil {
+				stringErr := fmt.Errorf("unsupported type : %s", reflect.TypeOf(tc.any))
+				if err.Error() != stringErr.Error() {
+					t.Errorf("%s: string error : %s, got %s", testName, stringErr, err)
+				}
+			} else {
+				if !reflect.DeepEqual(result, tc.string) {
+					t.Errorf("%s: byte %v, got %v", testName, tc.string, result)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
* Add Base64Encode function that works exactly the same as PHP 5.6's [base64_encode function](https://www.php.net/manual/en/function.base64-encode) using ZendParseArg function and [EncodeToString function](https://pkg.go.dev/encoding/base64#Encoding.EncodeToString) in the package encoding/base64.
## Reference
- [PHP base64_encode definition](https://github.com/php/php-src/blob/php-5.6.40/ext/standard/base64.c#L224-L241)
- [PHP base64_encode implementation](https://github.com/php/php-src/blob/4b8f72da5dfb201af4e82dee960261d8657e414f/ext/standard/base64.c#L56-L106)

