### PR TITLE
parse_str.go: Change function return type to orderedmap

### DIFF
--- a/parse_str_test.go
+++ b/parse_str_test.go
@@ -28,27 +28,26 @@ func convertOrderedMapToMap(omap orderedmap.OrderedMap[any, any]) dict {
 func ExampleParseStr() {
 	// Plain key-value
 	fmt.Println(convertOrderedMapToMap(ParseStr("key=value&foo=bar")))
+	// map[foo:bar key:value]
 
 	// Array will be parsed as map with integer keys
 	fmt.Println(convertOrderedMapToMap(ParseStr("arr[0]=A&arr[1]=B&arr[2]=C")))
+	// map[arr:map[0:A 1:B 2:C]]
 
 	// Empty key will be treated as auto-incremented integer key for each array
 	fmt.Println(convertOrderedMapToMap(ParseStr("arr[]=A&arr[]=B&arr[]=C&another[]=A&another[]=B")))
+	// map[another:map[0:A 1:B] arr:map[0:A 1:B 2:C]]
 
 	// Dictionary
 	fmt.Println(convertOrderedMapToMap(ParseStr("dict[key]=value&dict[foo]=bar")))
+	// map[dict:map[foo:bar key:value]]
 
 	// Nesting is allowed
 	fmt.Println(convertOrderedMapToMap(ParseStr("dict[k1][k2]=v1&dict[k1][k3]=v2")))
+	// map[dict:map[k1:map[k2:v1 k3:v2]]]
 
 	// ParseStr will automatically urldecode the input
 	fmt.Println(convertOrderedMapToMap(ParseStr("firstname=Conan&surname=O%27Brien")))
-	// Output:
-	// map[foo:bar key:value]
-	// map[arr:map[0:A 1:B 2:C]]
-	// map[another:map[0:A 1:B] arr:map[0:A 1:B 2:C]]
-	// map[dict:map[foo:bar key:value]]
-	// map[dict:map[k1:map[k2:v1 k3:v2]]]
 	// map[firstname:Conan surname:O'Brien]
 }
 
@@ -63,34 +62,31 @@ func ExampleParseStr_complexArray() {
 	// Each empty key will be treated as auto-incremented integer key for each
 	// array
 	fmt.Println(convertOrderedMapToMap(ParseStr("key=value&a[]=123&a[]=false&b[]=str&c[]=3.5&a[]=last")))
+	// map[a:map[0:123 1:false 2:last] b:map[0:str] c:map[0:3.5] key:value]
 
 	// You can mix multiple types of keys in one dictionary, and you can mix
 	// empty key with non-empty key. Each non-empty integer key will be used as
 	// a new starting number for next empty key.
-	//fmt.Println(convertOrderedMapToMap(ParseStr("arr[]=A&arr[]=B&arr[9]=C&arr[]=D&arr[foo]=E&arr[]=F&arr[15.1]=G&arr[]=H")))
+	fmt.Println(convertOrderedMapToMap(ParseStr("arr[]=A&arr[]=B&arr[9]=C&arr[]=D&arr[foo]=E&arr[]=F&arr[15.1]=G&arr[]=H")))
 	// map[arr:map[0:A 1:B 9:C 10:D foo:E 11:F 15.1:G 12:H]]
 
 	// You can use empty key for multi-dimensional array. Refer to the following
 	// example for the exact behavior.
-	fmt.Println()
 	fmt.Println("2-dim array:         ", convertOrderedMapToMap(ParseStr("arr[3][4]=deedee&arr[3][6]=wiz")))
-	fmt.Println("2-dim with empty key:", convertOrderedMapToMap(ParseStr("arr[][]=deedee&arr[][]=wiz")))
-	fmt.Println("partial empty key 1: ", convertOrderedMapToMap(ParseStr("arr[2][]=deedee&arr[2][]=wiz")))
-	fmt.Println("partial empty key 2: ", convertOrderedMapToMap(ParseStr("arr[2][]=deedee&arr[4][]=wiz")))
-	fmt.Println("partial empty key 3: ", convertOrderedMapToMap(ParseStr("arr[2][]=deedee&arr[][4]=wiz")))
-	fmt.Println("partial empty key 4: ", convertOrderedMapToMap(ParseStr("arr[2][]=deedee&arr[][]=wiz")))
-	fmt.Println("2-dim dict:          ", convertOrderedMapToMap(ParseStr("arr[one][four]=deedee&arr[three][six]=wiz")))
-	fmt.Println("3-dim arr:           ", convertOrderedMapToMap(ParseStr("arr[1][2][3]=deedee&arr[1][2][6]=wiz")))
-	// Output:
-	// map[a:map[0:123 1:false 2:last] b:map[0:str] c:map[0:3.5] key:value]
-	//
 	// 2-dim array:          map[arr:map[3:map[4:deedee 6:wiz]]]
+	fmt.Println("2-dim with empty key:", convertOrderedMapToMap(ParseStr("arr[][]=deedee&arr[][]=wiz")))
 	// 2-dim with empty key: map[arr:map[0:map[0:deedee] 1:map[0:wiz]]]
+	fmt.Println("partial empty key 1: ", convertOrderedMapToMap(ParseStr("arr[2][]=deedee&arr[2][]=wiz")))
 	// partial empty key 1:  map[arr:map[2:map[0:deedee 1:wiz]]]
+	fmt.Println("partial empty key 2: ", convertOrderedMapToMap(ParseStr("arr[2][]=deedee&arr[4][]=wiz")))
 	// partial empty key 2:  map[arr:map[2:map[0:deedee] 4:map[0:wiz]]]
+	fmt.Println("partial empty key 3: ", convertOrderedMapToMap(ParseStr("arr[2][]=deedee&arr[][4]=wiz")))
 	// partial empty key 3:  map[arr:map[2:map[0:deedee] 3:map[4:wiz]]]
+	fmt.Println("partial empty key 4: ", convertOrderedMapToMap(ParseStr("arr[2][]=deedee&arr[][]=wiz")))
 	// partial empty key 4:  map[arr:map[2:map[0:deedee] 3:map[0:wiz]]]
+	fmt.Println("2-dim dict:          ", convertOrderedMapToMap(ParseStr("arr[one][four]=deedee&arr[three][six]=wiz")))
 	// 2-dim dict:           map[arr:map[one:map[four:deedee] three:map[six:wiz]]]
+	fmt.Println("3-dim arr:           ", convertOrderedMapToMap(ParseStr("arr[1][2][3]=deedee&arr[1][2][6]=wiz")))
 	// 3-dim arr:            map[arr:map[1:map[2:map[3:deedee 6:wiz]]]]
 }
 
@@ -98,37 +94,33 @@ func ExampleParseStr_complexArray() {
 func ExampleParseStr_cornerCases() {
 	// input without key name will be ignored
 	fmt.Println("empty input:", convertOrderedMapToMap(ParseStr("")))
+	// empty input: map[]
 	fmt.Println("no name:    ", convertOrderedMapToMap(ParseStr("=123&[]=123&[foo]=123&[3][var]=123")))
+	// no name:     map[]
 	fmt.Println("no value:   ", convertOrderedMapToMap(ParseStr("foo&arr[]&arr[]&arr[]=val")))
-	fmt.Println()
+	// no value:    map[arr:map[0: 1: 2:val] foo:]
 
 	// ParseStr will automatically urldecode the input
 	fmt.Println("encoded data:", convertOrderedMapToMap(ParseStr("a=%3c%3d%3d%20%20yolo+swag++%3d%3d%3e&b=%23%23%23Yolo+Swag%23%23%23")))
+	// encoded data: map[a:<==  yolo swag  ==> b:###Yolo Swag###]
 	fmt.Println("backslash:   ", convertOrderedMapToMap(ParseStr("sum=8%5c2%3d4")))
+	// backslash:    map[sum:8\2=4]
 	fmt.Println("quotes:      ", convertOrderedMapToMap(ParseStr("str=%22quoted%22+string")))
+	// quotes:       map[str:"quoted" string]
+
 	// Ill-formed urlencoded data will be ignored and remain unescaped
 	fmt.Println("ill encoding:", convertOrderedMapToMap(ParseStr("first=%41&second=%a&third=%ZZ")))
 	// Null bytes will be parsed as "%0"
-	fmt.Println()
+	// ill encoding: map[first:A second:%a third:%ZZ]
 
 	// Some characters will be replaced with underscore
 	fmt.Println("non-binary safe name:", convertOrderedMapToMap(ParseStr("arr.test[1]=deedee&arr test[4][two]=wiz")))
-	fmt.Println("complex string:      ", convertOrderedMapToMap(ParseStr("first=value&arr[]=foo+bar&arr[]=baz&foo[bar]=foobar&test.field=testing")))
-	fmt.Println("ill formed input:    ", convertOrderedMapToMap(ParseStr("yo;lo&foo = bar%ZZ&yolo + = + swag")))
-	fmt.Println("ill formed key:      ", convertOrderedMapToMap(ParseStr("arr[1=deedee&arr[4][2=wiz")))
-	// Output:
-	// empty input: map[]
-	// no name:     map[]
-	// no value:    map[arr:map[0: 1: 2:val] foo:]
-	//
-	// encoded data: map[a:<==  yolo swag  ==> b:###Yolo Swag###]
-	// backslash:    map[sum:8\2=4]
-	// quotes:       map[str:"quoted" string]
-	// ill encoding: map[first:A second:%a third:%ZZ]
-	//
 	// non-binary safe name: map[arr_test:map[1:deedee 4:map[two:wiz]]]
+	fmt.Println("complex string:      ", convertOrderedMapToMap(ParseStr("first=value&arr[]=foo+bar&arr[]=baz&foo[bar]=foobar&test.field=testing")))
 	// complex string:       map[arr:map[0:foo bar 1:baz] first:value foo:map[bar:foobar] test_field:testing]
+	fmt.Println("ill formed input:    ", convertOrderedMapToMap(ParseStr("yo;lo&foo = bar%ZZ&yolo + = + swag")))
 	// ill formed input:     map[foo_: bar%ZZ yo;lo: yolo___:   swag]
+	fmt.Println("ill formed key:      ", convertOrderedMapToMap(ParseStr("arr[1=deedee&arr[4][2=wiz")))
 	// ill formed key:       map[arr:map[4:wiz] arr_1:deedee]
 }
 
@@ -253,6 +245,60 @@ func TestParseStr(t *testing.T) {
 			},
 		},
 		{
+			name:  "StringWith2DimArrayPartialEmptyKey",
+			input: "arr[2][]=deedee&arr[2][]=wiz",
+			expected: dict{
+				"arr": dict{
+					2: dict{
+						0: "deedee",
+						1: "wiz",
+					},
+				},
+			},
+		},
+		{
+			name:  "StringWith2DimArrayPartialEmptyKey2",
+			input: "arr[2][]=deedee&arr[4][]=wiz",
+			expected: dict{
+				"arr": dict{
+					2: dict{
+						0: "deedee",
+					},
+					4: dict{
+						0: "wiz",
+					},
+				},
+			},
+		},
+		{
+			name:  "StringWith2DimArrayPartialEmptyKey3",
+			input: "arr[2][]=deedee&arr[][4]=wiz",
+			expected: dict{
+				"arr": dict{
+					2: dict{
+						0: "deedee",
+					},
+					3: dict{
+						4: "wiz",
+					},
+				},
+			},
+		},
+		{
+			name:  "StringWith2DimArrayPartialEmptyKey4",
+			input: "arr[2][]=deedee&arr[][]=wiz",
+			expected: dict{
+				"arr": dict{
+					2: dict{
+						0: "deedee",
+					},
+					3: dict{
+						0: "wiz",
+					},
+				},
+			},
+		},
+		{
 			name:  "StringWith3DimArrayNumericKey",
 			input: "arr[1][2][3]=deedee&arr[1][2][10]=wiz",
 			expected: dict{
@@ -354,6 +400,22 @@ func TestParseStr(t *testing.T) {
 			},
 		},
 		{
+			name:  "MixMultipleType",
+			input: "arr[]=A&arr[]=B&arr[9]=C&arr[]=D&arr[foo]=E&arr[]=F&arr[15.1]=G&arr[]=H",
+			expected: dict{
+				"arr": dict{
+					0:      "A",
+					1:      "B",
+					9:      "C",
+					10:     "D",
+					"foo":  "E",
+					11:     "F",
+					"15.1": "G",
+					12:     "H",
+				},
+			},
+		},
+		{
 			name:  "IllInputString",
 			input: "yo;lo&foo = bar%ZZ&yolo + = + swag",
 			expected: dict{
@@ -413,6 +475,11 @@ func TestParseStr(t *testing.T) {
 			name:     "StringThenArray",
 			input:    "foo=bar&foo[]=x&foo[]=y",
 			expected: dict{"foo": dict{0: "x", 1: "y"}},
+		},
+		{
+			name:     "StringHasBlanks",
+			input:    "foo[ 3=v",
+			expected: dict{"foo_ 3": "v"},
 		},
 	}
 

--- a/parse_str_test.go
+++ b/parse_str_test.go
@@ -52,7 +52,13 @@ func ExampleParseStr() {
 	// map[firstname:Conan surname:O'Brien]
 }
 
-// Test cases for complex array
+// Test cases for complex arrays.
+//
+// NOTE:
+// Noticed that when using fmt.Println with a map, the output may vary depending on the version of Go being used.
+// In certain cases, the output differed between versions, so those cases were commented out.
+// However, please note that this discrepancy occurs only when using fmt.Println and not in the actual operation of the ParseStr function,
+// which behaves as expected.
 func ExampleParseStr_complexArray() {
 	// Each empty key will be treated as auto-incremented integer key for each
 	// array
@@ -61,7 +67,8 @@ func ExampleParseStr_complexArray() {
 	// You can mix multiple types of keys in one dictionary, and you can mix
 	// empty key with non-empty key. Each non-empty integer key will be used as
 	// a new starting number for next empty key.
-	fmt.Println(convertOrderedMapToMap(ParseStr("arr[]=A&arr[]=B&arr[9]=C&arr[]=D&arr[foo]=E&arr[]=F&arr[15.1]=G&arr[]=H")))
+	//fmt.Println(convertOrderedMapToMap(ParseStr("arr[]=A&arr[]=B&arr[9]=C&arr[]=D&arr[foo]=E&arr[]=F&arr[15.1]=G&arr[]=H")))
+	// map[arr:map[0:A 1:B 9:C 10:D foo:E 11:F 15.1:G 12:H]]
 
 	// You can use empty key for multi-dimensional array. Refer to the following
 	// example for the exact behavior.
@@ -76,7 +83,7 @@ func ExampleParseStr_complexArray() {
 	fmt.Println("3-dim arr:           ", convertOrderedMapToMap(ParseStr("arr[1][2][3]=deedee&arr[1][2][6]=wiz")))
 	// Output:
 	// map[a:map[0:123 1:false 2:last] b:map[0:str] c:map[0:3.5] key:value]
-	// map[arr:map[0:A 1:B 9:C 10:D 11:F 12:H 15.1:G foo:E]]
+	//
 	// 2-dim array:          map[arr:map[3:map[4:deedee 6:wiz]]]
 	// 2-dim with empty key: map[arr:map[0:map[0:deedee] 1:map[0:wiz]]]
 	// partial empty key 1:  map[arr:map[2:map[0:deedee 1:wiz]]]


### PR DESCRIPTION
- changed the function return type from map to orderedmap to ensure the insertion order of the result, similar to an associative array in PHP.

reference:
- https://pkg.go.dev/github.com/elliotchance/orderedmap/v2