### PR TITLE
convert_to_string: return "Object" for an object unavailable to be a string

### DIFF
--- a/zend_operator.go
+++ b/zend_operator.go
@@ -96,6 +96,7 @@ func ConvertToString(value any) (string, error) {
 		if result, ok := value.(toStringAble); ok {
 			return result.toString(), nil
 		}
+		return "Object", nil
 	}
 	// return an error for unsupported types.
 	return "", fmt.Errorf("unsupported type : %T", value)


### PR DESCRIPTION
Return"Object" string for a struct type value which is unavailable to be a string.

Reference: https://github.com/php/php-src/blob/php-5.6.40/Zend/zend_operators.c#L649-L652
